### PR TITLE
Command/Response directory refactor

### DIFF
--- a/rpc/src/commands/chains/blocks/get_balance.rs
+++ b/rpc/src/commands/chains/blocks/get_balance.rs
@@ -1,5 +1,5 @@
 use crate::commands::RpcClientCommand;
-use crate::responses::BalanceResponse;
+use crate::responses::chains::blocks::balance::BalanceResponse;
 use crate::types::{Block, Chain};
 
 pub struct GetBalance {

--- a/rpc/src/commands/chains/blocks/get_balance.rs
+++ b/rpc/src/commands/chains/blocks/get_balance.rs
@@ -1,4 +1,4 @@
-use super::RpcClientCommand;
+use crate::commands::RpcClientCommand;
 use crate::responses::BalanceResponse;
 use crate::types::{Block, Chain};
 

--- a/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
+++ b/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
@@ -1,5 +1,5 @@
 use crate::commands::RpcClientCommand;
-use crate::responses::BlocksInChainResponse;
+use crate::responses::chains::blocks::block_ids_in_chain::BlocksInChainResponse;
 use crate::types::Chain;
 
 pub struct GetBlocksInChain {

--- a/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
+++ b/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
@@ -1,4 +1,4 @@
-use super::RpcClientCommand;
+use crate::commands::RpcClientCommand;
 use crate::responses::BlocksInChainResponse;
 use crate::types::Chain;
 

--- a/rpc/src/commands/chains/blocks/mod.rs
+++ b/rpc/src/commands/chains/blocks/mod.rs
@@ -1,0 +1,2 @@
+pub mod get_balance;
+pub mod get_blocks_in_chain;

--- a/rpc/src/commands/chains/mod.rs
+++ b/rpc/src/commands/chains/mod.rs
@@ -1,0 +1,1 @@
+pub mod blocks;

--- a/rpc/src/commands/mod.rs
+++ b/rpc/src/commands/mod.rs
@@ -2,8 +2,6 @@ use crate::errors::ParseError;
 use crate::responses::Response;
 
 pub mod chains;
-pub use chains::blocks::get_balance::GetBalance;
-pub use chains::blocks::get_blocks_in_chain::GetBlocksInChain;
 
 pub trait RpcClientCommand {
     type R: Response;

--- a/rpc/src/commands/mod.rs
+++ b/rpc/src/commands/mod.rs
@@ -1,10 +1,9 @@
 use crate::errors::ParseError;
 use crate::responses::Response;
 
-mod get_balance;
-mod get_blocks_in_chain;
-pub use get_balance::GetBalance;
-pub use get_blocks_in_chain::GetBlocksInChain;
+pub mod chains;
+pub use chains::blocks::get_balance::GetBalance;
+pub use chains::blocks::get_blocks_in_chain::GetBlocksInChain;
 
 pub trait RpcClientCommand {
     type R: Response;

--- a/rpc/src/responses/chains/blocks/balance.rs
+++ b/rpc/src/responses/chains/blocks/balance.rs
@@ -1,5 +1,5 @@
-use super::ParseError;
-use super::Response;
+use crate::errors::ParseError;
+use crate::responses::Response;
 
 #[derive(Debug)]
 pub struct BalanceResponse {

--- a/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
+++ b/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
@@ -1,5 +1,5 @@
-use super::json_array;
-use super::{ParseError, Response};
+use crate::errors::ParseError;
+use crate::responses::{Response, json_array};
 use crate::types::Unistring;
 
 pub struct BlocksInChainResponse {

--- a/rpc/src/responses/chains/blocks/mod.rs
+++ b/rpc/src/responses/chains/blocks/mod.rs
@@ -1,0 +1,2 @@
+pub mod balance;
+pub mod block_ids_in_chain;

--- a/rpc/src/responses/chains/mod.rs
+++ b/rpc/src/responses/chains/mod.rs
@@ -1,0 +1,1 @@
+pub mod blocks;

--- a/rpc/src/responses/mod.rs
+++ b/rpc/src/responses/mod.rs
@@ -1,8 +1,6 @@
 pub mod chains;
 mod json_array;
 use crate::errors::ParseError;
-pub use chains::blocks::balance::BalanceResponse;
-pub use chains::blocks::block_ids_in_chain::BlocksInChainResponse;
 
 pub trait Response {
     fn from_response_str(response: &str) -> Result<Self, ParseError>

--- a/rpc/src/responses/mod.rs
+++ b/rpc/src/responses/mod.rs
@@ -1,9 +1,8 @@
-pub mod balance;
-pub mod block_ids_in_chain;
+pub mod chains;
 mod json_array;
 use crate::errors::ParseError;
-pub use balance::BalanceResponse;
-pub use block_ids_in_chain::BlocksInChainResponse;
+pub use chains::blocks::balance::BalanceResponse;
+pub use chains::blocks::block_ids_in_chain::BlocksInChainResponse;
 
 pub trait Response {
     fn from_response_str(response: &str) -> Result<Self, ParseError>

--- a/rpc/tests/rpc_command_tests/get_balance_from_block.rs
+++ b/rpc/tests/rpc_command_tests/get_balance_from_block.rs
@@ -1,5 +1,5 @@
 use super::*;
-use commands::GetBalance;
+use commands::chains::blocks::get_balance::GetBalance;
 
 #[tokio::test]
 async fn get_balance_for_bob_ok() {

--- a/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
+++ b/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
@@ -1,5 +1,5 @@
 use super::*;
-use commands::GetBlocksInChain;
+use commands::chains::blocks::get_blocks_in_chain::GetBlocksInChain;
 
 #[tokio::test]
 async fn get_blocks_in_chain_ok() {


### PR DESCRIPTION
Expand directory structure so that dir paths match endpoint paths. Right now only added `rpc/src/commands/chains/blocks` and `rpc/src/responses/chains/blocks` directory and moved corresponding commands/responses. Is this too convoluted?