### PR TITLE
Feature adding optional param to command

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 [dependencies]
 url = "2.2.1"
 chrono = "0.4.0"
+querystring = "1.1.0"
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1.0"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 
 [dependencies]
 url = "2.2.1"
+chrono = "0.4.0"
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1.0"

--- a/rpc/src/commands/chains/blocks/get_balance.rs
+++ b/rpc/src/commands/chains/blocks/get_balance.rs
@@ -1,5 +1,5 @@
+use super::block_responses::BalanceResponse;
 use crate::commands::RpcClientCommand;
-use crate::responses::chains::blocks::balance::BalanceResponse;
 use crate::types::{Block, Chain};
 
 pub struct GetBalance {

--- a/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
+++ b/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
@@ -2,10 +2,18 @@ use super::block_responses::BlocksInChainResponse;
 use crate::commands::RpcClientCommand;
 use crate::types::Chain;
 use chrono::NaiveDateTime;
+use querystring;
 
 type BlockHash = String;
 
 #[derive(Debug)]
+/// Command for the [`/chains/{chain_id}/blocks` endpoint](https://tezos.gitlab.io/shell/rpc.html#get-chains-chain-id-blocks).
+///
+/// Requires a valid [`chain_id`](Chain) to form the URL string
+///
+/// Can optionally hold extra query parameters with
+/// [an explicit constructor](Self::with_explicit_params),
+/// or default to sending no args with [the default constructor](Self::with_default_params)
 pub struct GetBlocksInChain {
     pub chain_id: Chain,
     params: Option<GetBlocksInChainParameters>,
@@ -20,19 +28,21 @@ struct GetBlocksInChainParameters {
 
 impl GetBlocksInChainParameters {
     fn to_url_string(&self) -> String {
-        let mut base_url = String::new();
+        let mut query_pairs = Vec::new();
 
         if let Some(length) = &self.length {
-            base_url.push_str(&length.to_string());
+            query_pairs.push(("length", length.to_string()));
         }
         if let Some(head) = &self.head {
-            base_url.push_str(&head);
+            query_pairs.push(("head", head.to_string()));
         }
         if let Some(min_date) = &self.min_date {
-            base_url.push_str(&min_date.timestamp().to_string());
+            query_pairs.push(("min_date", min_date.timestamp().to_string()));
         }
 
-        base_url
+        let query_params = query_pairs.iter().map(|x| (x.0, x.1.as_str())).collect();
+
+        querystring::stringify(query_params)
     }
 }
 

--- a/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
+++ b/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
@@ -19,33 +19,6 @@ pub struct GetBlocksInChain {
     params: Option<GetBlocksInChainParameters>,
 }
 
-#[derive(Debug)]
-struct GetBlocksInChainParameters {
-    length: Option<u32>,
-    head: Option<BlockHash>,
-    min_date: Option<NaiveDateTime>,
-}
-
-impl GetBlocksInChainParameters {
-    fn to_url_query_string(&self) -> String {
-        let mut query_pairs = Vec::new();
-
-        if let Some(length) = &self.length {
-            query_pairs.push(("length", length.to_string()));
-        }
-        if let Some(head) = &self.head {
-            query_pairs.push(("head", head.to_string()));
-        }
-        if let Some(min_date) = &self.min_date {
-            query_pairs.push(("min_date", min_date.timestamp().to_string()));
-        }
-
-        let query_params = query_pairs.iter().map(|x| (x.0, x.1.as_str())).collect();
-
-        querystring::stringify(query_params)
-    }
-}
-
 impl GetBlocksInChain {
     pub fn with_default_params(chain_id: Chain) -> Self {
         Self {
@@ -87,5 +60,116 @@ impl RpcClientCommand for GetBlocksInChain {
 
     fn get_http_method(&self) -> reqwest::Method {
         reqwest::Method::GET
+    }
+}
+
+#[derive(Debug)]
+struct GetBlocksInChainParameters {
+    length: Option<u32>,
+    head: Option<BlockHash>,
+    min_date: Option<NaiveDateTime>,
+}
+
+impl GetBlocksInChainParameters {
+    fn to_url_query_string(&self) -> String {
+        let mut query_pairs = Vec::new();
+
+        if let Some(length) = &self.length {
+            query_pairs.push(("length", length.to_string()));
+        }
+        if let Some(head) = &self.head {
+            query_pairs.push(("head", head.to_string()));
+        }
+        if let Some(min_date) = &self.min_date {
+            query_pairs.push(("min_date", min_date.timestamp().to_string()));
+        }
+
+        let query_params = query_pairs.iter().map(|x| (x.0, x.1.as_str())).collect();
+
+        querystring::stringify(query_params)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn all_params_some_to_string_ok() {
+        let length = 10;
+        let head = "head".to_string();
+        let min_date = NaiveDateTime::from_timestamp(0, 0);
+
+        let correct_query_string = format!(
+            "length={}&head={}&min_date={}&",
+            &length,
+            &head,
+            &min_date.timestamp()
+        );
+
+        let params = GetBlocksInChainParameters {
+            length: Some(length),
+            head: Some(head),
+            min_date: Some(min_date),
+        };
+
+        assert_eq!(correct_query_string, params.to_url_query_string());
+    }
+
+    #[test]
+    fn all_params_none_to_string_ok() {
+        let correct_query_string = "".to_string();
+
+        let params = GetBlocksInChainParameters {
+            length: None,
+            head: None,
+            min_date: None,
+        };
+
+        assert_eq!(correct_query_string, params.to_url_query_string());
+    }
+
+    #[test]
+    fn only_length_some_ok() {
+        let length = 10;
+
+        let correct_query_string = format!("length={}&", &length,);
+
+        let params = GetBlocksInChainParameters {
+            length: Some(length),
+            head: None,
+            min_date: None,
+        };
+
+        assert_eq!(correct_query_string, params.to_url_query_string());
+    }
+    #[test]
+    fn only_head_some_ok() {
+        let head = "head".to_string();
+
+        let correct_query_string = format!("head={}&", &head,);
+
+        let params = GetBlocksInChainParameters {
+            length: None,
+            head: Some(head),
+            min_date: None,
+        };
+
+        assert_eq!(correct_query_string, params.to_url_query_string());
+    }
+
+    #[test]
+    fn only_min_date_some_ok() {
+        let min_date = NaiveDateTime::from_timestamp(0, 0);
+
+        let correct_query_string = format!("min_date={}&", &min_date.timestamp());
+
+        let params = GetBlocksInChainParameters {
+            length: None,
+            head: None,
+            min_date: Some(min_date),
+        };
+
+        assert_eq!(correct_query_string, params.to_url_query_string());
     }
 }

--- a/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
+++ b/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
@@ -1,5 +1,5 @@
+use super::block_responses::BlocksInChainResponse;
 use crate::commands::RpcClientCommand;
-use crate::responses::chains::blocks::block_ids_in_chain::BlocksInChainResponse;
 use crate::types::Chain;
 
 pub struct GetBlocksInChain {

--- a/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
+++ b/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
@@ -1,16 +1,78 @@
 use super::block_responses::BlocksInChainResponse;
 use crate::commands::RpcClientCommand;
 use crate::types::Chain;
+use chrono::NaiveDateTime;
 
+type BlockHash = String;
+
+#[derive(Debug)]
 pub struct GetBlocksInChain {
     pub chain_id: Chain,
+    params: Option<GetBlocksInChainParameters>,
+}
+
+#[derive(Debug)]
+struct GetBlocksInChainParameters {
+    length: Option<u32>,
+    head: Option<BlockHash>,
+    min_date: Option<NaiveDateTime>,
+}
+
+impl GetBlocksInChainParameters {
+    fn to_url_string(&self) -> String {
+        let mut base_url = String::new();
+
+        if let Some(length) = &self.length {
+            base_url.push_str(&length.to_string());
+        }
+        if let Some(head) = &self.head {
+            base_url.push_str(&head);
+        }
+        if let Some(min_date) = &self.min_date {
+            base_url.push_str(&min_date.timestamp().to_string());
+        }
+
+        base_url
+    }
+}
+
+impl GetBlocksInChain {
+    pub fn with_default_params(chain_id: Chain) -> Self {
+        Self {
+            chain_id,
+            params: None,
+        }
+    }
+
+    pub fn with_explicit_params(
+        chain_id: Chain,
+        length: Option<u32>,
+        head: Option<BlockHash>,
+        min_date: Option<NaiveDateTime>,
+    ) -> Self {
+        let params = GetBlocksInChainParameters {
+            length,
+            head,
+            min_date,
+        };
+
+        Self {
+            chain_id,
+            params: Some(params),
+        }
+    }
 }
 
 impl RpcClientCommand for GetBlocksInChain {
     type R = BlocksInChainResponse;
 
     fn get_url_string(&self) -> String {
-        format!("chains/{}/blocks", self.chain_id.to_str())
+        let mut url_string = format!("chains/{}/blocks", self.chain_id.to_str());
+        if let Some(params) = &self.params {
+            url_string.push('?');
+            url_string.push_str(&params.to_url_string());
+        }
+        url_string
     }
 
     fn get_http_method(&self) -> reqwest::Method {

--- a/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
+++ b/rpc/src/commands/chains/blocks/get_blocks_in_chain.rs
@@ -27,7 +27,7 @@ struct GetBlocksInChainParameters {
 }
 
 impl GetBlocksInChainParameters {
-    fn to_url_string(&self) -> String {
+    fn to_url_query_string(&self) -> String {
         let mut query_pairs = Vec::new();
 
         if let Some(length) = &self.length {
@@ -80,7 +80,7 @@ impl RpcClientCommand for GetBlocksInChain {
         let mut url_string = format!("chains/{}/blocks", self.chain_id.to_str());
         if let Some(params) = &self.params {
             url_string.push('?');
-            url_string.push_str(&params.to_url_string());
+            url_string.push_str(&params.to_url_query_string());
         }
         url_string
     }

--- a/rpc/src/commands/chains/blocks/mod.rs
+++ b/rpc/src/commands/chains/blocks/mod.rs
@@ -1,2 +1,3 @@
 pub mod get_balance;
 pub mod get_blocks_in_chain;
+use crate::responses::chains::blocks as block_responses;

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -69,7 +69,6 @@ impl RpcClient {
     ) -> Result<<T as RpcClientCommand>::R, errors::RpcError> {
         let raw_endpoint_url = format!("{}{}", self.tezos_node_url, command.get_url_string());
         let endpoint_url = reqwest::Url::parse(&raw_endpoint_url)?;
-        println!("cont: {}", &endpoint_url);
 
         let request = self.client.request(command.get_http_method(), endpoint_url);
         let response_str = request.send().await?.text().await?;

--- a/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
+++ b/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
@@ -9,7 +9,7 @@ pub struct BlocksInChainResponse {
 
 impl Response for BlocksInChainResponse {
     /// Parses a response string in the form
-    /// `"[["alpha_numeric_block_id_string"], ["..."]]"` or
+    /// `"[["alpha_numeric_block_id_string", "..."], ["...", "..."]]"` or
     /// `[[{ "invalid_utf8_string": [ integer ∈ [0, 255] ... ] }], [...]]` into a
     /// [`BlocksInChainResponse`](Self).
     fn from_response_str(response: &str) -> Result<Self, ParseError> {

--- a/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
+++ b/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
@@ -1,5 +1,5 @@
 use crate::errors::ParseError;
-use crate::responses::{json_array, Response};
+use crate::responses::{json_array::JsonArray, Response};
 use crate::types::Unistring;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -7,7 +7,7 @@ use std::fmt;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct BlocksInChainResponse {
-    pub block_ids: json_array::JsonArray<Unistring>,
+    pub block_ids: JsonArray<JsonArray<Unistring>>,
 }
 
 impl fmt::Display for BlocksInChainResponse {
@@ -22,7 +22,7 @@ impl Response for BlocksInChainResponse {
     /// `[[{ "invalid_utf8_string": [ integer ∈ [0, 255] ... ] }], [...]]` into a
     /// [`BlocksInChainResponse`](Self).
     fn from_response_str(response: &str) -> Result<Self, ParseError> {
-        let block_ids = json_array::JsonArray::from_response_str(response)?;
+        let block_ids = JsonArray::from_nested_response_str(response)?;
 
         Ok(Self { block_ids })
     }
@@ -68,6 +68,8 @@ mod test {
         let mock_response = format!(r#"[["{}"]]"#, mock_block_id);
 
         let blocks_response = BlocksInChainResponse::from_response_str(&mock_response);
+        println!("{:?}", blocks_response);
+        panic!();
         assert!(blocks_response.is_ok());
 
         let mut blocks = blocks_response.unwrap().block_ids.into_vec();

--- a/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
+++ b/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
@@ -69,8 +69,6 @@ mod test {
 
         let blocks_response = BlocksInChainResponse::from_response_str(&mock_response);
         println!("{:?}", blocks_response);
-        panic!();
-        assert!(blocks_response.is_ok());
 
         let mut blocks = blocks_response.unwrap().block_ids.into_vec();
         assert!(blocks.len() == 1);

--- a/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
+++ b/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
@@ -1,7 +1,8 @@
 use crate::errors::ParseError;
-use crate::responses::{Response, json_array};
+use crate::responses::{json_array, Response};
 use crate::types::Unistring;
 
+#[derive(Debug)]
 pub struct BlocksInChainResponse {
     pub block_ids: json_array::JsonArray<Unistring>,
 }

--- a/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
+++ b/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
@@ -33,17 +33,64 @@ mod test {
     use super::*;
 
     #[test]
-    fn get_blocks_in_chain_from_response_empty_fail() {
-        let mock_response = "";
+    fn get_blocks_in_chain_from_nested_irregular_array_ok() {
+        let mock_arr_1 = ["blockId1", "blockId2", "blockId3"];
+        let mock_arr_2 = ["blockId4", "blockId5"];
+        let mock_response_str = format!("[{:?}, {:?}]", &mock_arr_1, &mock_arr_2);
 
-        let blocks_response = BlocksInChainResponse::from_response_str(mock_response);
+        let blocks_response = BlocksInChainResponse::from_response_str(&mock_response_str);
+        assert!(blocks_response.is_ok());
+
+        let blocks = blocks_response.unwrap().block_ids.into_vec();
+        let mut zipped_tuple_iter = mock_arr_1
+            .iter()
+            .chain(mock_arr_2.iter())
+            .zip(blocks.into_iter().flatten());
+
+        while let Some(tuple) = zipped_tuple_iter.next() {
+            let mock_str = *tuple.0;
+            let parsed_response = tuple.1;
+            assert_eq!(parsed_response, mock_str);
+        }
+    }
+
+    #[test]
+    fn get_blocks_in_chain_from_nested_regular_array_ok() {
+        let mock_block_id = [
+            ["blockId1", "blockId2", "blockId3"],
+            ["blockId4", "blockId5", "blockId6"],
+        ];
+        let mock_response_str = format!("{:?}", &mock_block_id);
+
+        let blocks_response = BlocksInChainResponse::from_response_str(&mock_response_str);
+
+        let blocks = blocks_response.unwrap().block_ids.into_vec();
+        assert_eq!(blocks.len(), mock_block_id.len());
+
+        let mut zipped_tuple_iter = mock_block_id
+            .iter()
+            .flatten()
+            .zip(blocks.into_iter().flatten());
+
+        while let Some(tuple) = zipped_tuple_iter.next() {
+            let mock_str = *tuple.0;
+            let parsed_response = tuple.1;
+            assert_eq!(parsed_response, mock_str);
+        }
+    }
+
+    #[test]
+    fn get_blocks_in_chain_from_response_empty_fail() {
+        let mock_response_str = "";
+
+        let blocks_response = BlocksInChainResponse::from_response_str(mock_response_str);
         assert!(blocks_response.is_err());
     }
 
     #[test]
     fn get_blocks_in_chain_from_empty_list_ok() {
-        let mock_response = "[]";
-        let blocks_response = BlocksInChainResponse::from_response_str(mock_response);
+        let mock_response_str = "[]";
+        let blocks_response = BlocksInChainResponse::from_response_str(mock_response_str);
         assert!(blocks_response.is_ok());
 
         let blocks = blocks_response.unwrap().block_ids.into_vec();
@@ -52,9 +99,9 @@ mod test {
 
     #[test]
     fn get_blocks_in_chain_from_empty_bulk_array_response_ok() {
-        let mock_response = "[[]]";
+        let mock_response_str = "[[]]";
 
-        let blocks_response = BlocksInChainResponse::from_response_str(mock_response);
+        let blocks_response = BlocksInChainResponse::from_response_str(mock_response_str);
         assert!(blocks_response.is_ok());
 
         let mut blocks = blocks_response.unwrap().block_ids.into_vec();
@@ -65,9 +112,9 @@ mod test {
     #[test]
     fn get_blocks_in_chain_from_response_single_ok() {
         let mock_block_id = "blockId1";
-        let mock_response = format!(r#"[["{}"]]"#, mock_block_id);
+        let mock_response_str = format!(r#"[["{}"]]"#, mock_block_id);
 
-        let blocks_response = BlocksInChainResponse::from_response_str(&mock_response);
+        let blocks_response = BlocksInChainResponse::from_response_str(&mock_response_str);
 
         let mut blocks = blocks_response.unwrap().block_ids.into_vec();
         assert!(blocks.len() == 1);
@@ -82,9 +129,9 @@ mod test {
     #[test]
     fn get_blocks_in_chain_from_invalid_utf8_response_single_ok() {
         let mock_nested_object = r#"{"invalid_utf8_string":[1,2,3,4]}"#;
-        let mock_response = format!(r#"[[{}]]"#, mock_nested_object);
+        let mock_response_str = format!(r#"[[{}]]"#, mock_nested_object);
 
-        let blocks_response = BlocksInChainResponse::from_response_str(&mock_response);
+        let blocks_response = BlocksInChainResponse::from_response_str(&mock_response_str);
         assert!(blocks_response.is_ok());
 
         let mut blocks = blocks_response.unwrap().block_ids.into_vec();
@@ -100,7 +147,7 @@ mod test {
     #[test]
     fn get_blocks_in_chain_from_response_multiple_ok() {
         let mock_block_ids = ["blockId1", "blockId2", "blockId3"];
-        let mock_response = format!(
+        let mock_response_str = format!(
             "[{}]",
             mock_block_ids
                 .iter()
@@ -109,7 +156,7 @@ mod test {
                 .join(",")
         );
 
-        let blocks_response = BlocksInChainResponse::from_response_str(&mock_response);
+        let blocks_response = BlocksInChainResponse::from_response_str(&mock_response_str);
         assert!(blocks_response.is_ok());
 
         let mut blocks = blocks_response.unwrap().block_ids.into_vec();

--- a/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
+++ b/rpc/src/responses/chains/blocks/block_ids_in_chain.rs
@@ -68,7 +68,6 @@ mod test {
         let mock_response = format!(r#"[["{}"]]"#, mock_block_id);
 
         let blocks_response = BlocksInChainResponse::from_response_str(&mock_response);
-        println!("{:?}", blocks_response);
 
         let mut blocks = blocks_response.unwrap().block_ids.into_vec();
         assert!(blocks.len() == 1);

--- a/rpc/src/responses/chains/blocks/invalid_blocks_in_chain.rs
+++ b/rpc/src/responses/chains/blocks/invalid_blocks_in_chain.rs
@@ -47,10 +47,10 @@ impl Response for InvalidBlocksInChainResponse {
     ///      "errors": $error }, ...]"` into a
     /// [`InvalidBlocksInChainResponse`](Self).
     fn from_response_str(response: &str) -> Result<Self, ParseError> {
-        let invalid_blocks = json_array::JsonArray::from_nested_response_str(response)?
-            .into_vec()
-            .pop()
-            .unwrap();
+        let invalid_blocks = json_array::JsonArray::from_response_str(response)?;
+        // .into_vec()
+        // .pop()
+        // .unwrap();
 
         Ok(Self { invalid_blocks })
     }
@@ -66,15 +66,18 @@ mod test {
 
         let parse_response = InvalidBlocksInChainResponse::from_response_str(&mock_response);
 
-        println!("RESP RESULT: {:?}", &parse_response);
         assert!(parse_response.is_ok());
 
         let mut invalid_blocks = parse_response.unwrap().invalid_blocks.into_vec();
         assert!(invalid_blocks.len() == 1);
 
         let invalid_block = invalid_blocks.pop().unwrap();
-        let invalid_block_array_str = format!("[{}]", invalid_block);
-        assert_eq!(invalid_block_array_str, mock_response);
+        let invalid_block_array_string = {
+            let block_array_string = format!("[{}]", invalid_block);
+            trim_and_remove_whitespace_from_string(block_array_string)
+        };
+
+        assert_eq!(invalid_block_array_string, mock_response);
     }
 
     #[test]
@@ -159,7 +162,8 @@ mod test {
             mock_extra_value
         );
 
-        mock_error_response.replace('\n', "").replace('\t', "")
+        let trimmed_string = trim_and_remove_whitespace_from_string(mock_error_response);
+        trimmed_string
     }
 
     fn format_response_data_as_string(
@@ -176,6 +180,14 @@ mod test {
             mock_block, mock_level, mock_error_response
         );
 
-        mock_response.replace('\n', "").replace('\t', "")
+        let trimmed_string = trim_and_remove_whitespace_from_string(mock_response);
+        trimmed_string
+    }
+
+    fn trim_and_remove_whitespace_from_string(pre_format_string: String) -> String {
+        pre_format_string
+            .replacen(' ', "", usize::MAX)
+            .replace('\n', "")
+            .replace('\t', "")
     }
 }

--- a/rpc/src/responses/chains/blocks/invalid_blocks_in_chain.rs
+++ b/rpc/src/responses/chains/blocks/invalid_blocks_in_chain.rs
@@ -8,146 +8,154 @@ use std::fmt;
 
 #[derive(Serialize, Deserialize)]
 pub struct InvalidBlockError {
-	pub kind: String,
-	pub id: String,
-	pub invalid_block: Unistring,
-	pub error: String,
-	#[serde(flatten)]
-	pub extra_error_info: HashMap<String, Value>,
+    pub kind: String,
+    pub id: String,
+    pub invalid_block: Unistring,
+    pub error: String,
+    #[serde(flatten)]
+    pub extra_error_info: HashMap<String, Value>,
 }
 
 impl fmt::Display for InvalidBlockError {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "{}", json!(self).to_string())
-	}
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", json!(self).to_string())
+    }
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct InvalidBlock {
-	pub block: Unistring,
-	pub level: i32,
-	pub errors: InvalidBlockError,
+    pub block: Unistring,
+    pub level: i32,
+    pub errors: InvalidBlockError,
 }
 
 impl fmt::Display for InvalidBlock {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "{}", json!(self).to_string())
-	}
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", json!(self).to_string())
+    }
 }
 
 pub struct InvalidBlocksInChainResponse {
-	pub invalid_blocks: json_array::JsonArray<InvalidBlock>,
+    pub invalid_blocks: json_array::JsonArray<InvalidBlock>,
 }
 
 impl Response for InvalidBlocksInChainResponse {
-	/// Parses a response string in the form
-	/// `"[{ "block": "alpha_numeric_block_id_string",
-	///      "level": integer ∈ [-2^31-1, 2^31],
-	///      "errors": $error }, ...]"` into a
-	/// [`InvalidBlocksInChainResponse`](Self).
-	fn from_response_str(response: &str) -> Result<Self, ParseError> {
-		let invalid_blocks = json_array::JsonArray::from_response_str(response)?;
+    /// Parses a response string in the form
+    /// `"[{ "block": "alpha_numeric_block_id_string",
+    ///      "level": integer ∈ [-2^31-1, 2^31],
+    ///      "errors": $error }, ...]"` into a
+    /// [`InvalidBlocksInChainResponse`](Self).
+    fn from_response_str(response: &str) -> Result<Self, ParseError> {
+        let invalid_blocks = json_array::JsonArray::from_response_str(response)?;
 
-		Ok(Self { invalid_blocks })
-	}
+        Ok(Self { invalid_blocks })
+    }
 }
 
 #[cfg(test)]
 mod test {
-	use super::*;
+    use super::*;
 
-	fn get_mock_error_response(
-		mock_kind: &str,
-		mock_id: &str,
-		mock_invalid_block_hash: &str,
-		mock_error: &str,
-		mock_extra_key: &str,
-		mock_extra_value: &str,
-	) -> String {
-		let mock_error_response = format!(
-			r#"{{
+    fn get_mock_error_response(
+        mock_kind: &str,
+        mock_id: &str,
+        mock_invalid_block_hash: &str,
+        mock_error: &str,
+        mock_extra_key: &str,
+        mock_extra_value: &str,
+    ) -> String {
+        let mock_error_response = format!(
+            r#"{{
 				"kind":"{}",
 				"id":"{}",
 				"invalid_block":"{}",
 				"error":"{}",
 				"{}":"{}"
 			}}"#,
-			mock_kind, mock_id, mock_invalid_block_hash, mock_error, mock_extra_key, mock_extra_value
-		);
+            mock_kind,
+            mock_id,
+            mock_invalid_block_hash,
+            mock_error,
+            mock_extra_key,
+            mock_extra_value
+        );
 
-		mock_error_response.replace('\n', "").replace('\t', "")
-	}
+        mock_error_response.replace('\n', "").replace('\t', "")
+    }
 
-	fn get_mock_response(mock_block: &str, mock_level: i32, mock_error_response: &str) -> String {
-		let mock_response = format!(
-			r#"[{{
+    fn get_mock_response(mock_block: &str, mock_level: i32, mock_error_response: &str) -> String {
+        let mock_response = format!(
+            r#"[{{
 				"block":"{}",
 				"level":{},
 				"errors":{}
 			}}]"#,
-			mock_block, mock_level, mock_error_response
-		);
+            mock_block, mock_level, mock_error_response
+        );
 
-		mock_response.replace('\n', "").replace('\t', "")
-	}
+        mock_response.replace('\n', "").replace('\t', "")
+    }
 
-	#[test]
-	fn get_invalid_blocks_in_chain_from_response_empty_fails() {
-		let mock_response = "";
+    #[test]
+    fn get_invalid_blocks_in_chain_from_response_empty_fails() {
+        let mock_response = "";
 
-		let invalid_blocks_response = InvalidBlocksInChainResponse::from_response_str(mock_response);
-		assert!(invalid_blocks_response.is_err());
-	}
+        let invalid_blocks_response =
+            InvalidBlocksInChainResponse::from_response_str(mock_response);
+        assert!(invalid_blocks_response.is_err());
+    }
 
-	#[test]
-	fn get_invalid_blocks_in_chain_from_response_ok() {
-		let mock_block = "blockId1";
-		let mock_level = 1;
+    #[test]
+    fn get_invalid_blocks_in_chain_from_response_ok() {
+        let mock_block = "blockId1";
+        let mock_level = 1;
 
-		let mock_kind = "permanent";
-		let mock_id = "validator.invalid_block";
-		let mock_invalid_block_hash = "blockId1";
-		let mock_error = "cannot_parse_operation";
-		let mock_extra_key = "operation";
-		let mock_extra_value = "operationHash1";
+        let mock_kind = "permanent";
+        let mock_id = "validator.invalid_block";
+        let mock_invalid_block_hash = "blockId1";
+        let mock_error = "cannot_parse_operation";
+        let mock_extra_key = "operation";
+        let mock_extra_value = "operationHash1";
 
-		let mock_error_response = get_mock_error_response(
-			mock_kind,
-			mock_id,
-			mock_invalid_block_hash,
-			mock_error,
-			mock_extra_key,
-			mock_extra_value,
-		);
+        let mock_error_response = get_mock_error_response(
+            mock_kind,
+            mock_id,
+            mock_invalid_block_hash,
+            mock_error,
+            mock_extra_key,
+            mock_extra_value,
+        );
 
-		let mock_response = get_mock_response(mock_block, mock_level, &mock_error_response);
+        let mock_response = get_mock_response(mock_block, mock_level, &mock_error_response);
 
-		let invalid_blocks_response = InvalidBlocksInChainResponse::from_response_str(&mock_response);
-		assert!(invalid_blocks_response.is_ok());
+        let invalid_blocks_response =
+            InvalidBlocksInChainResponse::from_response_str(&mock_response);
+        assert!(invalid_blocks_response.is_ok());
 
-		let mut invalid_blocks = invalid_blocks_response.unwrap().invalid_blocks.into_vec();
-		assert!(invalid_blocks.len() == 1);
+        let mut invalid_blocks = invalid_blocks_response.unwrap().invalid_blocks.into_vec();
+        assert!(invalid_blocks.len() == 1);
 
-		let invalid_block = invalid_blocks.pop().unwrap();
-		let invalid_block_array_str = format!("[{}]", invalid_block);
-		assert_eq!(invalid_block_array_str, mock_response);
-	}
+        let invalid_block = invalid_blocks.pop().unwrap();
+        let invalid_block_array_str = format!("[{}]", invalid_block);
+        assert_eq!(invalid_block_array_str, mock_response);
+    }
 
-	#[test]
-	fn get_invalid_blocks_in_chain_from_malformed_response_fails() {
-		let mock_block = "blockId2";
-		let mock_level = 2;
+    #[test]
+    fn get_invalid_blocks_in_chain_from_malformed_response_fails() {
+        let mock_block = "blockId2";
+        let mock_level = 2;
 
-		// Mock response without errors field, which is required for all type of errors
-		let mock_response = format!(
-			r#"[{{
+        // Mock response without errors field, which is required for all type of errors
+        let mock_response = format!(
+            r#"[{{
 				"block":"{}",
 				"level":{},
 			}}]"#,
-			mock_block, mock_level
-		);
+            mock_block, mock_level
+        );
 
-		let invalid_blocks_response = InvalidBlocksInChainResponse::from_response_str(&mock_response);
-		assert!(invalid_blocks_response.is_err());
-	}
+        let invalid_blocks_response =
+            InvalidBlocksInChainResponse::from_response_str(&mock_response);
+        assert!(invalid_blocks_response.is_err());
+    }
 }

--- a/rpc/src/responses/chains/blocks/invalid_blocks_in_chain.rs
+++ b/rpc/src/responses/chains/blocks/invalid_blocks_in_chain.rs
@@ -48,10 +48,6 @@ impl Response for InvalidBlocksInChainResponse {
     /// [`InvalidBlocksInChainResponse`](Self).
     fn from_response_str(response: &str) -> Result<Self, ParseError> {
         let invalid_blocks = json_array::JsonArray::from_response_str(response)?;
-        // .into_vec()
-        // .pop()
-        // .unwrap();
-
         Ok(Self { invalid_blocks })
     }
 }

--- a/rpc/src/responses/chains/blocks/mod.rs
+++ b/rpc/src/responses/chains/blocks/mod.rs
@@ -1,2 +1,4 @@
 pub mod balance;
 pub mod block_ids_in_chain;
+pub use balance::BalanceResponse;
+pub use block_ids_in_chain::BlocksInChainResponse;

--- a/rpc/src/responses/json_array.rs
+++ b/rpc/src/responses/json_array.rs
@@ -68,7 +68,7 @@ impl<T: de::DeserializeOwned> JsonArray<JsonArray<T>> {
         Ok(JsonArray { items })
     }
 
-    pub fn to_flattened_vec(self) -> Vec<T> {
+    pub fn into_flattened_vec(self) -> Vec<T> {
         self.into_iter().flatten().collect()
     }
 }
@@ -225,7 +225,7 @@ mod test {
         let response = parse_response.unwrap();
 
         let flattened_mock_value_vec: Vec<&&str> = mock_values.iter().flatten().collect();
-        let flattened_response_vec = response.to_flattened_vec();
+        let flattened_response_vec = response.into_flattened_vec();
 
         assert_eq!(flattened_response_vec.len(), flattened_mock_value_vec.len());
 

--- a/rpc/src/responses/json_array.rs
+++ b/rpc/src/responses/json_array.rs
@@ -2,6 +2,7 @@ use super::ParseError;
 use serde::de;
 use serde_json::{self, json, Value};
 
+#[derive(Debug)]
 pub struct JsonArray<T> {
     flattened_vec: Vec<T>,
 }

--- a/rpc/src/responses/json_array.rs
+++ b/rpc/src/responses/json_array.rs
@@ -4,9 +4,16 @@ use serde_json::{self, Value};
 use std::array::IntoIter;
 use std::fmt;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct JsonArray<T> {
     items: Vec<T>,
+}
+
+impl<T: de::DeserializeOwned + fmt::Debug> JsonArray<JsonArray<T>> {
+    pub fn from_nested_response_str(nested_json_str: &str) -> Result<Self, ParseError> {
+        let inner = Self::from_response_str(nested_json_str)?.into_vec();
+        Ok(Self { items: inner })
+    }
 }
 
 impl<T: de::DeserializeOwned> JsonArray<T> {

--- a/rpc/src/responses/json_array.rs
+++ b/rpc/src/responses/json_array.rs
@@ -85,14 +85,14 @@ impl<T> iter::IntoIterator for JsonArray<T> {
 impl<T: fmt::Display> fmt::Display for JsonArray<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.items.is_empty() {
-            write!(f, "")
+            write!(f, "[]")
         } else {
             let mut display_string = String::new();
             for value in &self.items {
                 display_string.push_str(&format!("{}, ", value));
             }
             display_string.truncate(display_string.len() - 2);
-            write!(f, "{}", display_string)
+            write!(f, "[{}]", display_string)
         }
     }
 }
@@ -249,10 +249,10 @@ mod test {
         assert!(parse_response.is_ok());
 
         let json_array = parse_response.unwrap();
-        let string_to_compare = format!("{}, {}", mock_values[0], mock_values[1]);
-        assert_eq!(json_array.to_string(), string_to_compare);
+        assert_eq!(json_array.len(), mock_values.len());
 
-        assert_eq!(json_array.into_vec().len(), mock_values.len());
+        let string_to_compare = format!("[{}, {}]", mock_values[0], mock_values[1]);
+        assert_eq!(json_array.to_string(), string_to_compare);
     }
 
     #[test]

--- a/rpc/src/responses/json_array.rs
+++ b/rpc/src/responses/json_array.rs
@@ -5,7 +5,7 @@ use std::fmt;
 
 #[derive(Debug)]
 pub struct JsonArray<T> {
-    flattened_vec: Vec<T>,
+    nested_vec: Vec<Vec<T>>,
 }
 
 impl<T: de::DeserializeOwned> JsonArray<T> {
@@ -21,7 +21,6 @@ impl<T: de::DeserializeOwned> JsonArray<T> {
                 true => unwrap_item_in_nested_json_array(nested_entry.take())?,
                 false => nested_entry.take(),
             };
-            let converted_item: T = serde_json::from_value(parsed_item_value)?;
             flattened_vec.push(converted_item);
         }
 
@@ -45,22 +44,21 @@ impl<T: fmt::Display> fmt::Display for JsonArray<T> {
     }
 }
 
-// fn unwrap_item_in_nested_json_array<T: de::DeserializeOwned>(
-// mut nested_item: Value,
-// ) -> Result<T, ParseError> {
-fn unwrap_item_in_nested_json_array(mut nested_item: Value) -> Result<Value, ParseError> {
+fn unwrap_item_in_nested_json_array<T: de::DeserializeOwned>(
+    mut nested_item: Value,
+) -> Result<T, ParseError> {
     let nested_array = nested_item
         .as_array_mut()
         .ok_or_else(|| generate_none_error("invalid initial json array"))?;
 
-    // for item in nested_array {
-    // let converted_item: T = serde_json::from_value(
-    // }
-
-    match nested_array.last() {
-        Some(_) => Ok(nested_array.pop().unwrap()),
-        None => Ok(json!("")),
+    for item in nested_array {
+        let converted_item: T = serde_json::from_value(item);
     }
+
+    // match nested_array.last() {
+    // Some(_) => Ok(nested_array.pop().unwrap()),
+    // None => Ok(json!("")),
+    // }
 }
 
 fn generate_none_error(detail: &str) -> ParseError {

--- a/rpc/src/responses/json_array.rs
+++ b/rpc/src/responses/json_array.rs
@@ -67,7 +67,6 @@ impl JsonArray<JsonArray<Unistring>> {
 
         let mut items = Vec::new();
         for mut item in outer_array {
-            println!("{:?}", item);
             let json_item = JsonArray::from_json_array(&mut item)?;
             items.push(json_item);
         }

--- a/rpc/src/responses/json_array.rs
+++ b/rpc/src/responses/json_array.rs
@@ -12,13 +12,17 @@ pub struct JsonArray<T> {
 impl<T: de::DeserializeOwned + fmt::Debug> JsonArray<JsonArray<T>> {
     pub fn from_nested_response_str(nested_json_str: &str) -> Result<Self, ParseError> {
         let inner = Self::from_response_str(nested_json_str)?.into_vec();
+        println!("{:?}", &inner);
         Ok(Self { items: inner })
     }
 }
 
-impl<T: de::DeserializeOwned> JsonArray<T> {
+impl<T: de::DeserializeOwned + fmt::Debug> JsonArray<T> {
     pub fn from_response_str(str_to_parse: &str) -> Result<Self, ParseError> {
-        let items = try_parse_array_into_item_from_response_str(str_to_parse)?;
+        let x = try_parse_array_into_item_from_response_str(str_to_parse);
+        println!("{:?}", &x);
+        // let items = try_parse_array_into_item_from_response_str(str_to_parse)?;
+        let items = x?;
         Ok(Self { items })
     }
 

--- a/rpc/src/responses/json_array.rs
+++ b/rpc/src/responses/json_array.rs
@@ -1,6 +1,7 @@
 use super::ParseError;
 use serde::de;
 use serde_json::{self, json, Value};
+use std::fmt;
 
 #[derive(Debug)]
 pub struct JsonArray<T> {
@@ -32,10 +33,30 @@ impl<T: de::DeserializeOwned> JsonArray<T> {
     }
 }
 
+impl<T: fmt::Display> fmt::Display for JsonArray<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut display_string = String::from("[");
+        for value in &self.flattened_vec {
+            display_string.push_str(&format!("{}, ", value.to_string()));
+        }
+        display_string.truncate(display_string.len() - 2);
+        display_string.push_str("]");
+        write!(f, "{}", display_string)
+    }
+}
+
+// fn unwrap_item_in_nested_json_array<T: de::DeserializeOwned>(
+// mut nested_item: Value,
+// ) -> Result<T, ParseError> {
 fn unwrap_item_in_nested_json_array(mut nested_item: Value) -> Result<Value, ParseError> {
     let nested_array = nested_item
         .as_array_mut()
         .ok_or_else(|| generate_none_error("invalid initial json array"))?;
+
+    // for item in nested_array {
+    // let converted_item: T = serde_json::from_value(
+    // }
+
     match nested_array.last() {
         Some(_) => Ok(nested_array.pop().unwrap()),
         None => Ok(json!("")),
@@ -44,4 +65,43 @@ fn unwrap_item_in_nested_json_array(mut nested_item: Value) -> Result<Value, Par
 
 fn generate_none_error(detail: &str) -> ParseError {
     ParseError::ResponseParsingError(detail.to_string())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn one_dimensional_json_array_parse_ok() {
+        let mock_values = ["foo", "bar"];
+        let mock_str_to_parse = format!(r#"[["{}"], ["{}"]]"#, mock_values[0], mock_values[1]);
+
+        let parse_response = JsonArray::<String>::from_str(&mock_str_to_parse);
+        assert!(parse_response.is_ok());
+
+        let json_array = parse_response.unwrap();
+        let string_to_compare = format!("[{}, {}]", mock_values[0], mock_values[1]);
+        assert_eq!(json_array.to_string(), string_to_compare);
+
+        assert_eq!(json_array.into_vec().len(), mock_values.len());
+    }
+
+    #[test]
+    fn no_json_array_values_parse_ok() {
+        let mock_str_to_parse = "[]";
+
+        let parse_response = JsonArray::<String>::from_str(&mock_str_to_parse);
+        assert!(parse_response.is_ok());
+
+        let json_array = parse_response.unwrap().into_vec();
+        assert_eq!(json_array.len(), 0);
+    }
+
+    #[test]
+    fn empty_json_str_fail() {
+        let mock_str_to_parse = "";
+
+        let parse_response = JsonArray::<String>::from_str(&mock_str_to_parse);
+        assert!(parse_response.is_err());
+    }
 }

--- a/rpc/src/responses/json_array.rs
+++ b/rpc/src/responses/json_array.rs
@@ -21,12 +21,11 @@ impl<T> iter::IntoIterator for JsonArray<T> {
 
 impl<T: fmt::Display> fmt::Display for JsonArray<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut display_string = String::from("[");
+        let mut display_string = String::new();
         for value in &self.items {
             display_string.push_str(&format!("{}, ", value.to_string()));
         }
         display_string.truncate(display_string.len() - 2);
-        display_string.push_str("]");
         write!(f, "{}", display_string)
     }
 }

--- a/rpc/src/types/chain.rs
+++ b/rpc/src/types/chain.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 pub enum Chain {
     Main,
     Test,

--- a/rpc/src/types/unistring.rs
+++ b/rpc/src/types/unistring.rs
@@ -9,6 +9,42 @@ pub enum Unistring {
     InvalidUtf8 { invalid_utf8_string: Vec<u8> },
 }
 
+impl PartialEq<str> for &Unistring {
+    fn eq(&self, other: &str) -> bool {
+        match self {
+            Unistring::ValidUtf8(utf8_string) => utf8_string == other,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<&str> for Unistring {
+    fn eq(&self, other: &&str) -> bool {
+        match self {
+            Self::ValidUtf8(utf8_string) => utf8_string == other,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<&&str> for Unistring {
+    fn eq(&self, other: &&&str) -> bool {
+        match self {
+            Self::ValidUtf8(utf8_string) => utf8_string == *other,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<str> for Unistring {
+    fn eq(&self, other: &str) -> bool {
+        match self {
+            Self::ValidUtf8(utf8_string) => utf8_string == other,
+            _ => false,
+        }
+    }
+}
+
 impl fmt::Display for Unistring {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/rpc/src/types/unistring.rs
+++ b/rpc/src/types/unistring.rs
@@ -1,30 +1,30 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
 pub enum Unistring {
-  ValidUtf8(String),
-  InvalidUtf8 { invalid_utf8_string: Vec<u8> },
+    ValidUtf8(String),
+    InvalidUtf8 { invalid_utf8_string: Vec<u8> },
 }
 
 impl Unistring {
-  pub fn get_string(&self) -> String {
-    match self {
-      Self::ValidUtf8(valid_utf8) => valid_utf8.to_string(),
-      Self::InvalidUtf8 {
-        invalid_utf8_string: invalid_bytes,
-      } => get_invalid_utf8(invalid_bytes),
+    pub fn get_string(&self) -> String {
+        match self {
+            Self::ValidUtf8(valid_utf8) => valid_utf8.to_string(),
+            Self::InvalidUtf8 {
+                invalid_utf8_string: invalid_bytes,
+            } => get_invalid_utf8(invalid_bytes),
+        }
     }
-  }
 }
 
 fn get_invalid_utf8(invalid_bytes: &[u8]) -> String {
-  format!(
-    r#"{{ "invalid_utf8_string": [{}] }}"#,
-    invalid_bytes
-      .iter()
-      .map(|byte| byte.to_string())
-      .collect::<Vec<String>>()
-      .join(", ")
-  )
+    format!(
+        r#"{{ "invalid_utf8_string": [{}] }}"#,
+        invalid_bytes
+            .iter()
+            .map(|byte| byte.to_string())
+            .collect::<Vec<String>>()
+            .join(", ")
+    )
 }

--- a/rpc/src/types/unistring.rs
+++ b/rpc/src/types/unistring.rs
@@ -27,15 +27,6 @@ impl PartialEq<&str> for Unistring {
     }
 }
 
-impl PartialEq<&&str> for Unistring {
-    fn eq(&self, other: &&&str) -> bool {
-        match self {
-            Self::ValidUtf8(utf8_string) => utf8_string == *other,
-            _ => false,
-        }
-    }
-}
-
 impl PartialEq<str> for Unistring {
     fn eq(&self, other: &str) -> bool {
         match self {

--- a/rpc/tests/rpc_command_tests/get_balance_from_block.rs
+++ b/rpc/tests/rpc_command_tests/get_balance_from_block.rs
@@ -13,7 +13,7 @@ async fn get_balance_for_bob_ok() {
     assert!(raw_response.is_ok());
 
     let response = raw_response.unwrap();
-    assert_eq!(response.balance, 0);
+    assert!(response.balance > 0);
 }
 
 #[tokio::test]
@@ -29,7 +29,7 @@ async fn get_balance_for_alice_ok() {
     assert!(raw_response.is_ok());
 
     let response = raw_response.unwrap();
-    assert_eq!(response.balance, 0);
+    assert!(response.balance > 0);
 }
 
 fn get_contract_id_for_fake_wallet_bob() -> String {

--- a/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
+++ b/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
@@ -66,7 +66,7 @@ async fn get_blocks_optional_length_ok() {
     let last_block_batch = blocks.pop();
     assert!(last_block_batch.is_some());
 
-    // assert_eq!(last_block_batch.unwrap().len(), length as usize);
+    assert_eq!(last_block_batch.unwrap().len(), length as usize);
 }
 
 fn generate_get_blocks_command_with_explicit_params(

--- a/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
+++ b/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
@@ -103,6 +103,64 @@ async fn get_block_optional_min_date_now_ok() {
     assert_eq!(blocks.len(), 0);
 }
 
+#[tokio::test]
+async fn get_blocks_with_min_date_and_length_ok() {
+    let min_date = Some(get_test_naive_datetime_at_epoch());
+    let length = Some(5);
+
+    let command = generate_get_blocks_command_with_explicit_params(length, None, min_date);
+
+    let client = get_rpc_client();
+    assert!(client.check_node_online().await);
+
+    let client_response = client.execute(&command).await;
+    assert!(client_response.is_ok());
+
+    let block_response = client_response.unwrap();
+    let blocks = block_response.block_ids;
+
+    assert_eq!(blocks.len(), length.unwrap() as usize);
+}
+
+#[tokio::test]
+async fn get_blocks_with_head_and_length_ok() {
+    let length = Some(5);
+    let head_hash = Some("BKmXPAiniarmJAxvv3T3CQ9sa42TbLiDdE6c57Gc74NjcKNFQBE".to_string());
+
+    let command = generate_get_blocks_command_with_explicit_params(length, head_hash, None);
+
+    let client = get_rpc_client();
+    assert!(client.check_node_online().await);
+
+    let client_response = client.execute(&command).await;
+    assert!(client_response.is_ok());
+
+    let block_response = client_response.unwrap();
+    let blocks = block_response.block_ids;
+
+    assert_eq!(blocks.len(), 1);
+}
+
+#[tokio::test]
+async fn get_blocks_all_optional_args_ok() {
+    let length = Some(5);
+    let min_date = Some(get_test_naive_datetime_at_epoch());
+    let head_hash = Some("BKmXPAiniarmJAxvv3T3CQ9sa42TbLiDdE6c57Gc74NjcKNFQBE".to_string());
+
+    let command = generate_get_blocks_command_with_explicit_params(length, head_hash, min_date);
+
+    let client = get_rpc_client();
+    assert!(client.check_node_online().await);
+
+    let client_response = client.execute(&command).await;
+    assert!(client_response.is_ok());
+
+    let block_response = client_response.unwrap();
+    let blocks = block_response.block_ids;
+
+    assert_eq!(blocks.len(), 1);
+}
+
 fn generate_get_blocks_command_with_explicit_params(
     length: Option<u32>,
     head_hash: Option<String>,

--- a/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
+++ b/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
@@ -23,8 +23,20 @@ fn generate_get_blocks_command_for_main_chain() -> GetBlocksInChain {
 }
 
 #[tokio::test]
-async fn get_blocks_in_chain_optional_params_ok() {
-    let command = generate_get_blocks_command_with_explicit_params();
+async fn get_blocks_with_optional_params_bad_head_hash_fail() {
+    let bad_head_hash = "".to_string();
+    let command = generate_get_blocks_command_with_explicit_params(None, Some(bad_head_hash), None);
+    let client = get_rpc_client();
+    assert!(client.check_node_online().await);
+
+    let client_response = client.execute(&command).await;
+    assert!(client_response.is_err());
+}
+
+#[tokio::test]
+async fn get_blocks_from_head_optional_params_ok() {
+    let head_hash = "BKmXPAiniarmJAxvv3T3CQ9sa42TbLiDdE6c57Gc74NjcKNFQBE".to_string();
+    let command = generate_get_blocks_command_with_explicit_params(None, Some(head_hash), None);
 
     let client = get_rpc_client();
     assert!(client.check_node_online().await);
@@ -33,18 +45,39 @@ async fn get_blocks_in_chain_optional_params_ok() {
     assert!(client_response.is_ok());
 
     let block_response = client_response.unwrap();
-    println!("resp: {:?}", block_response);
-    panic!();
     let blocks = block_response.block_ids.into_vec();
-    assert!(blocks.len() > 0);
+    assert!(blocks.len() >= 1);
 }
 
-fn generate_get_blocks_command_with_explicit_params() -> GetBlocksInChain {
+#[tokio::test]
+async fn get_blocks_optional_length_ok() {
+    let length = 5;
+    let command = generate_get_blocks_command_with_explicit_params(Some(length), None, None);
+
+    let client = get_rpc_client();
+    assert!(client.check_node_online().await);
+
+    let client_response = client.execute(&command).await;
+    assert!(client_response.is_ok());
+
+    let block_response = client_response.unwrap();
+    let blocks = block_response.block_ids.into_vec();
+    println!("{:?}", blocks);
+    panic!();
+
+    let last_block_batch = blocks.pop();
+    assert!(last_block_batch.is_some());
+
+    // assert_eq!(last_block_batch.unwrap().len(), length as usize);
+}
+
+fn generate_get_blocks_command_with_explicit_params(
+    length: Option<u32>,
+    head_hash: Option<String>,
+    min_date: Option<NaiveDateTime>,
+) -> GetBlocksInChain {
     let chain_id = get_main_chain_id_by_tag();
-    let length = Some(10);
-    let head = Some(String::from(""));
-    let min_date = Some(get_test_naive_datetime_at_epoc());
-    GetBlocksInChain::with_explicit_params(chain_id, length, head, min_date)
+    GetBlocksInChain::with_explicit_params(chain_id, length, head_hash, min_date)
 }
 
 fn get_test_naive_datetime_at_epoc() -> NaiveDateTime {

--- a/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
+++ b/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
@@ -17,11 +17,6 @@ async fn get_blocks_in_chain_ok() {
     assert!(blocks.len() > 0);
 }
 
-fn generate_get_blocks_command_for_main_chain() -> GetBlocksInChain {
-    let chain_id = get_main_chain_id_by_tag();
-    GetBlocksInChain::with_default_params(chain_id)
-}
-
 #[tokio::test]
 async fn get_blocks_with_optional_params_bad_head_hash_fail() {
     let bad_head_hash = "".to_string();
@@ -61,12 +56,11 @@ async fn get_blocks_optional_length_ok() {
     assert!(client_response.is_ok());
 
     let block_response = client_response.unwrap();
-    let mut blocks = block_response.block_ids.into_vec();
+    let nested_blocks = block_response.block_ids;
 
-    let last_block_batch = blocks.pop();
-    assert!(last_block_batch.is_some());
-
-    assert_eq!(last_block_batch.unwrap().len(), length as usize);
+    for block in nested_blocks {
+        assert_eq!(block.len(), length as usize);
+    }
 }
 
 #[tokio::test]
@@ -117,9 +111,11 @@ async fn get_blocks_with_min_date_and_length_ok() {
     assert!(client_response.is_ok());
 
     let block_response = client_response.unwrap();
-    let blocks = block_response.block_ids;
+    let nested_blocks = block_response.block_ids;
 
-    assert_eq!(blocks.len(), length.unwrap() as usize);
+    for block in nested_blocks {
+        assert_eq!(block.len(), length.unwrap() as usize);
+    }
 }
 
 #[tokio::test]
@@ -136,9 +132,9 @@ async fn get_blocks_with_head_and_length_ok() {
     assert!(client_response.is_ok());
 
     let block_response = client_response.unwrap();
-    let blocks = block_response.block_ids;
+    let flattened_blocks = block_response.block_ids.into_flattened_vec();
 
-    assert_eq!(blocks.len(), 1);
+    assert_eq!(flattened_blocks.len(), length.unwrap() as usize);
 }
 
 #[tokio::test]
@@ -156,9 +152,9 @@ async fn get_blocks_all_optional_args_ok() {
     assert!(client_response.is_ok());
 
     let block_response = client_response.unwrap();
-    let blocks = block_response.block_ids;
+    let flattened_blocks = block_response.block_ids.into_flattened_vec();
 
-    assert_eq!(blocks.len(), 1);
+    assert_eq!(flattened_blocks.len(), length.unwrap() as usize);
 }
 
 fn generate_get_blocks_command_with_explicit_params(
@@ -176,4 +172,9 @@ fn get_naive_datetime_for_now() -> NaiveDateTime {
 
 fn get_test_naive_datetime_at_epoch() -> NaiveDateTime {
     NaiveDateTime::from_timestamp(0, 0)
+}
+
+fn generate_get_blocks_command_for_main_chain() -> GetBlocksInChain {
+    let chain_id = get_main_chain_id_by_tag();
+    GetBlocksInChain::with_default_params(chain_id)
 }

--- a/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
+++ b/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
@@ -1,4 +1,5 @@
 use super::*;
+use chrono::NaiveDateTime;
 use commands::chains::blocks::get_blocks_in_chain::GetBlocksInChain;
 
 #[tokio::test]
@@ -18,5 +19,34 @@ async fn get_blocks_in_chain_ok() {
 
 fn generate_get_blocks_command_for_main_chain() -> GetBlocksInChain {
     let chain_id = get_main_chain_id_by_tag();
-    GetBlocksInChain { chain_id }
+    GetBlocksInChain::with_default_params(chain_id)
+}
+
+#[tokio::test]
+async fn get_blocks_in_chain_optional_params_ok() {
+    let command = generate_get_blocks_command_with_explicit_params();
+
+    let client = get_rpc_client();
+    assert!(client.check_node_online().await);
+
+    let client_response = client.execute(&command).await;
+    assert!(client_response.is_ok());
+
+    let block_response = client_response.unwrap();
+    println!("resp: {:?}", block_response);
+    panic!();
+    let blocks = block_response.block_ids.into_vec();
+    assert!(blocks.len() > 0);
+}
+
+fn generate_get_blocks_command_with_explicit_params() -> GetBlocksInChain {
+    let chain_id = get_main_chain_id_by_tag();
+    let length = Some(10);
+    let head = Some(String::from(""));
+    let min_date = Some(get_test_naive_datetime_at_epoc());
+    GetBlocksInChain::with_explicit_params(chain_id, length, head, min_date)
+}
+
+fn get_test_naive_datetime_at_epoc() -> NaiveDateTime {
+    NaiveDateTime::from_timestamp(0, 0)
 }

--- a/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
+++ b/rpc/tests/rpc_command_tests/get_blocks_in_chain.rs
@@ -61,9 +61,7 @@ async fn get_blocks_optional_length_ok() {
     assert!(client_response.is_ok());
 
     let block_response = client_response.unwrap();
-    let blocks = block_response.block_ids.into_vec();
-    println!("{:?}", blocks);
-    panic!();
+    let mut blocks = block_response.block_ids.into_vec();
 
     let last_block_batch = blocks.pop();
     assert!(last_block_batch.is_some());
@@ -80,6 +78,6 @@ fn generate_get_blocks_command_with_explicit_params(
     GetBlocksInChain::with_explicit_params(chain_id, length, head_hash, min_date)
 }
 
-fn get_test_naive_datetime_at_epoc() -> NaiveDateTime {
+fn _get_test_naive_datetime_at_epoc() -> NaiveDateTime {
     NaiveDateTime::from_timestamp(0, 0)
 }


### PR DESCRIPTION
Implementing two major features (as per [the issue linked to this pr](#6)):
1. optional url query args for the rpc call to the endpoint
2. extend `JsonArray` to hold true representation of 2D array responses from the RPC

The optional url params were done with an internal `struct GetBlocksInChainParameters` that is only exposed through the `command` constructors.